### PR TITLE
Cria color header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.out
 *.exe
 *.ppm
+*.bat
 
 main

--- a/Projeto/Includes/color.h
+++ b/Projeto/Includes/color.h
@@ -1,0 +1,20 @@
+#ifndef COLOR_H
+#define COLOR_H
+
+#include "../../External/glm/glm.hpp"
+
+#include <iostream>
+
+using color = glm::vec3;
+
+void write_color(std::ostream &out, color pixel_color) {
+
+    int ir = int(255.99*pixel_color[0]);
+    int ig = int(255.99*pixel_color[1]);
+    int ib = int(255.99*pixel_color[2]);
+
+    out << ir << " " << ig << " " << ib << "\n";
+    
+}
+
+#endif

--- a/Projeto/main.cpp
+++ b/Projeto/main.cpp
@@ -2,6 +2,7 @@
 #include "../External/glm/glm.hpp" // forma de importar o glm.hpp
 #include "../External/glm/gtc/matrix_transform.hpp" // essa diretiva é necessária pra executar o código da linha 12
 #include "./Includes/ray.h"
+#include "./Includes/color.h"
 
 float hit_sphere(const glm::vec3& center, float radius, const ray& r) // função que checa se o ray se intercepta com a esfera
 {
@@ -23,18 +24,18 @@ float hit_sphere(const glm::vec3& center, float radius, const ray& r) // funçã
 
 
 // função que define a cor que será exibida
-glm::vec3 color(const ray& r)
+color ray_color(const ray& r)
 {
     float t = hit_sphere(glm::vec3(0.0f, 0.0f, -1.0f), 0.5f, r);// checa se o raio intercepta a esfera
     if(t > 0.0){
         glm::vec3 N = normalize(r.point_at_parameter(t) - glm::vec3(0.0f, 0.0f, -1.0f));// calcula o vetor normal
-        return 0.5f * glm::vec3(N.x + 1.0f, N.y + 1.0f, N.z + 1.0f); // retorna a cor
+        return 0.5f * color(N.x + 1.0f, N.y + 1.0f, N.z + 1.0f); // retorna a cor
     }
-    glm::vec3 aux1(1.0f, 1.0f, 1.0f);
-    glm::vec3 aux2(0.5f, 0.7f, 1.0f);
+    color startColor(1.0f, 1.0f, 1.0f);
+    color endColor(0.5f, 0.7f, 1.0f);
     glm::vec3 unit_direction = normalize(r.direction());
     t = 0.5f * (unit_direction.y + 1.0f);
-    return ((1.0f - t) * aux1) + (t * aux2);
+    return ((1.0f - t) * startColor) + (t * endColor);
 }
 
 int main() {
@@ -62,12 +63,8 @@ int main() {
             float v = float(j)/ float(ny);
             ray r(origin, lower_left_corner + u*horizontal + v*vertical);
 
-            glm::vec3 col = color(r);
-            int ir = int(255.99*col[0]);
-            int ig = int(255.99*col[1]);
-            int ib = int(255.99*col[2]);
-
-            std::cout << ir << " " << ig << " " << ib << "\n"; 
+            color pixel_color = ray_color(r);
+            write_color(std::cout, pixel_color);
         }
     }
 


### PR DESCRIPTION
- Define o header "color" para usar o tipo "glm::vec3" como "color" e também a função para escrever o RGB no cout.
- Muda no main o tipo das variáveis color, e o nome da função para calcular a cor do ray agora é "ray_color"
